### PR TITLE
feat: Add notification permission request for Android 13+ (Issue #24)

### DIFF
--- a/app/src/main/java/com/github/melq/howmanydays/MainActivity.kt
+++ b/app/src/main/java/com/github/melq/howmanydays/MainActivity.kt
@@ -1,16 +1,33 @@
 package com.github.melq.howmanydays
 
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
 
 class MainActivity : ComponentActivity() {
+    private val requestPermissionLauncher =
+            registerForActivityResult(ActivityResultContracts.RequestPermission()) {
+                    isGranted: Boolean ->
+                // 権限の結果によって処理を分けることができますが、今回は特に何もしません
+            }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
-        setContent {
-            HowManyDaysApp()
+        setContent { HowManyDaysApp() }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            if (ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) !=
+                            PackageManager.PERMISSION_GRANTED
+            ) {
+                requestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+            }
         }
     }
 }

--- a/app/src/main/java/com/github/melq/howmanydays/MainActivity.kt
+++ b/app/src/main/java/com/github/melq/howmanydays/MainActivity.kt
@@ -14,7 +14,6 @@ class MainActivity : ComponentActivity() {
     private val requestPermissionLauncher =
             registerForActivityResult(ActivityResultContracts.RequestPermission()) {
                     isGranted: Boolean ->
-                // 権限の結果によって処理を分けることができますが、今回は特に何もしません
             }
 
     override fun onCreate(savedInstanceState: Bundle?) {


### PR DESCRIPTION
This PR implements the runtime permission request for POST_NOTIFICATIONS on Android 13 (API 33) and above. It ensures that the app can display notifications on newer Android versions. Closes #24.