### PR TITLE
feat(#29): 通知のオン/オフ設定を追加

### DIFF
--- a/app/src/main/java/com/github/melq/howmanydays/HowManyDaysApplication.kt
+++ b/app/src/main/java/com/github/melq/howmanydays/HowManyDaysApplication.kt
@@ -36,11 +36,13 @@ class HowManyDaysApplication : Application(), Configuration.Provider {
     private fun observeNotificationSettings() {
         scope.launch {
             val repository = container.notificationSettingsRepository
-            repository.notificationHour
-                    .combine(repository.notificationMinute) { hour, minute -> Pair(hour, minute) }
-                    .collect { (hour, minute) ->
-                        scheduleDailyCheck(this@HowManyDaysApplication, hour, minute)
-                    }
+            repository.notificationSettings.collect { settings ->
+                if (settings.isEnabled) {
+                    scheduleDailyCheck(this@HowManyDaysApplication, settings.hour, settings.minute)
+                } else {
+                    WorkManager.getInstance(this@HowManyDaysApplication).cancelUniqueWork("DailyCheckWork")
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/github/melq/howmanydays/data/repository/NotificationSettingsRepository.kt
+++ b/app/src/main/java/com/github/melq/howmanydays/data/repository/NotificationSettingsRepository.kt
@@ -3,6 +3,7 @@ package com.github.melq.howmanydays.data.repository
 import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
@@ -11,10 +12,15 @@ import kotlinx.coroutines.flow.map
 
 val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "settings")
 
+data class NotificationSettings(
+    val hour: Int,
+    val minute: Int,
+    val isEnabled: Boolean
+)
+
 interface INotificationSettingsRepository {
-    val notificationHour: Flow<Int>
-    val notificationMinute: Flow<Int>
-    suspend fun saveNotificationTime(hour: Int, minute: Int)
+    val notificationSettings: Flow<NotificationSettings>
+    suspend fun saveNotificationSettings(hour: Int, minute: Int, isEnabled: Boolean)
 }
 
 class NotificationSettingsRepository(private val context: Context) :
@@ -22,18 +28,23 @@ class NotificationSettingsRepository(private val context: Context) :
     companion object {
         val HOUR = intPreferencesKey("notification_hour")
         val MINUTE = intPreferencesKey("notification_minute")
+        val IS_ENABLED = booleanPreferencesKey("notification_enabled")
     }
 
-    override val notificationHour: Flow<Int> =
-            context.dataStore.data.map { preferences -> preferences[HOUR] ?: 9 }
+    override val notificationSettings: Flow<NotificationSettings> =
+            context.dataStore.data.map { preferences ->
+                NotificationSettings(
+                    hour = preferences[HOUR] ?: 9,
+                    minute = preferences[MINUTE] ?: 0,
+                    isEnabled = preferences[IS_ENABLED] ?: true
+                )
+            }
 
-    override val notificationMinute: Flow<Int> =
-            context.dataStore.data.map { preferences -> preferences[MINUTE] ?: 0 }
-
-    override suspend fun saveNotificationTime(hour: Int, minute: Int) {
+    override suspend fun saveNotificationSettings(hour: Int, minute: Int, isEnabled: Boolean) {
         context.dataStore.edit { preferences ->
             preferences[HOUR] = hour
             preferences[MINUTE] = minute
+            preferences[IS_ENABLED] = isEnabled
         }
     }
 }

--- a/app/src/main/java/com/github/melq/howmanydays/ui/screens/NotificationTimeSettingScreen.kt
+++ b/app/src/main/java/com/github/melq/howmanydays/ui/screens/NotificationTimeSettingScreen.kt
@@ -10,11 +10,17 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.Switch
 import androidx.compose.material3.TimePicker
 import androidx.compose.material3.rememberTimePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -23,10 +29,9 @@ import com.github.melq.howmanydays.viewmodel.SettingsViewModel
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun NotificationTimeSettingScreen(viewModel: SettingsViewModel, onNavigateBack: () -> Unit) {
-        val hour by viewModel.notificationHour.collectAsState()
-        val minute by viewModel.notificationMinute.collectAsState()
+        val settingsState by viewModel.notificationSettings.collectAsState()
 
-        if (hour < 0 || minute < 0) {
+        val currentSettings = settingsState ?: run {
                 Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                         CircularProgressIndicator()
                 }
@@ -34,13 +39,27 @@ fun NotificationTimeSettingScreen(viewModel: SettingsViewModel, onNavigateBack: 
         }
 
         val timePickerState =
-                rememberTimePickerState(initialHour = hour, initialMinute = minute, is24Hour = true)
+                rememberTimePickerState(initialHour = currentSettings.hour, initialMinute = currentSettings.minute, is24Hour = true)
+
+        var currentIsEnabled by remember(currentSettings.isEnabled) { mutableStateOf(currentSettings.isEnabled) }
 
         Column(
                 modifier = Modifier.fillMaxSize().padding(16.dp),
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.Center
         ) {
+                Row(
+                        modifier = Modifier.fillMaxWidth().padding(bottom = 32.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                ) {
+                        Text("通知を有効にする", style = MaterialTheme.typography.bodyLarge)
+                        Switch(
+                                checked = currentIsEnabled,
+                                onCheckedChange = { currentIsEnabled = it }
+                        )
+                }
+
                 Text(
                         text = "通知時間の指定",
                         style = MaterialTheme.typography.headlineMedium,
@@ -51,9 +70,10 @@ fun NotificationTimeSettingScreen(viewModel: SettingsViewModel, onNavigateBack: 
 
                 Button(
                         onClick = {
-                                viewModel.saveNotificationTime(
+                                viewModel.saveNotificationSettings(
                                         timePickerState.hour,
-                                        timePickerState.minute
+                                        timePickerState.minute,
+                                        currentIsEnabled
                                 )
                                 onNavigateBack()
                         },

--- a/app/src/main/java/com/github/melq/howmanydays/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/github/melq/howmanydays/ui/screens/SettingsScreen.kt
@@ -28,7 +28,7 @@ fun SettingsScreen(onNavigateToNotificationTime: () -> Unit) {
                         }
                         item {
                                 SettingItem(
-                                        title = "通知時間の設定",
+                                        title = "通知の設定",
                                         onClick = onNavigateToNotificationTime
                                 )
                                 HorizontalDivider()

--- a/app/src/main/java/com/github/melq/howmanydays/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/github/melq/howmanydays/viewmodel/SettingsViewModel.kt
@@ -3,6 +3,7 @@ package com.github.melq.howmanydays.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.github.melq.howmanydays.data.repository.INotificationSettingsRepository
+import com.github.melq.howmanydays.data.repository.NotificationSettings
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
@@ -12,23 +13,16 @@ class SettingsViewModel(
         private val notificationSettingsRepository: INotificationSettingsRepository
 ) : ViewModel() {
 
-        val notificationHour: StateFlow<Int> =
-                notificationSettingsRepository.notificationHour.stateIn(
+        val notificationSettings: StateFlow<NotificationSettings?> =
+                notificationSettingsRepository.notificationSettings.stateIn(
                         scope = viewModelScope,
                         started = SharingStarted.WhileSubscribed(5000),
-                        initialValue = -1
+                        initialValue = null
                 )
 
-        val notificationMinute: StateFlow<Int> =
-                notificationSettingsRepository.notificationMinute.stateIn(
-                        scope = viewModelScope,
-                        started = SharingStarted.WhileSubscribed(5000),
-                        initialValue = -1
-                )
-
-        fun saveNotificationTime(hour: Int, minute: Int) {
+        fun saveNotificationSettings(hour: Int, minute: Int, isEnabled: Boolean) {
                 viewModelScope.launch {
-                        notificationSettingsRepository.saveNotificationTime(hour, minute)
+                        notificationSettingsRepository.saveNotificationSettings(hour, minute, isEnabled)
                 }
         }
 }


### PR DESCRIPTION
Closes #29

## 概要
通知機能そのもののオン/オフを切り替えられるように、設定画面にトグルスイッチを追加しました。それに伴い、設定画面の項目名を「通知時間の設定」から「通知の設定」に変更しました。

## 補足
- 通知設定がオフの場合でも時間の操作は可能な仕様としています。
- 通知設定がオフに切り替わった場合、\WorkManager\ に積まれている \DailyCheckWork\ をキャンセルし、実際にバックグラウンドからの通知が発送されないように制御しています。
- DataStoreの購読部分が肥大化しないように、通知関連の設定を \NotificationSettings\ データクラスに集約し、シンプルに1つのFlowで購読できるようにリファクタリングを行いました。